### PR TITLE
Fix parseInt usage

### DIFF
--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -264,7 +264,7 @@ export class SingleSessionHTTPServer {
       }
     });
     
-    const port = parseInt(process.env.PORT || '3000');
+    const port = parseInt(process.env.PORT || '3000', 10);
     const host = process.env.HOST || '0.0.0.0';
     
     this.expressServer = app.listen(port, host, () => {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -330,7 +330,7 @@ export async function startFixedHTTPServer() {
     }
   });
   
-  const port = parseInt(process.env.PORT || '3000');
+  const port = parseInt(process.env.PORT || '3000', 10);
   const host = process.env.HOST || '0.0.0.0';
   
   expressServer = app.listen(port, host, () => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -747,7 +747,7 @@ Full documentation is being prepared. For now, use get_node_essentials for confi
       // Handle array notation like parameters[0]
       const arrayMatch = part.match(/^(\w+)\[(\d+)\]$/);
       if (arrayMatch) {
-        value = value?.[arrayMatch[1]]?.[parseInt(arrayMatch[2])];
+        value = value?.[arrayMatch[1]]?.[parseInt(arrayMatch[2], 10)];
       } else {
         value = value?.[part];
       }

--- a/src/services/node-documentation-service.ts
+++ b/src/services/node-documentation-service.ts
@@ -518,7 +518,7 @@ CREATE TABLE IF NOT EXISTS extraction_stats (
       // Version
       const versionMatch = sourceCode.match(/version\s*[:=]\s*(\d+)/);
       if (versionMatch) {
-        result.version = parseInt(versionMatch[1]);
+        result.version = parseInt(versionMatch[1], 10);
       }
       
       // Subtitle

--- a/src/utils/n8n-errors.ts
+++ b/src/utils/n8n-errors.ts
@@ -75,7 +75,7 @@ export function handleN8nApiError(error: unknown): N8nApiError {
           return new N8nValidationError(message, data);
         case 429:
           const retryAfter = axiosError.response.headers['retry-after'];
-          return new N8nRateLimitError(retryAfter ? parseInt(retryAfter) : undefined);
+          return new N8nRateLimitError(retryAfter ? parseInt(retryAfter, 10) : undefined);
         default:
           if (status >= 500) {
             return new N8nServerError(message, status);


### PR DESCRIPTION
## Summary
- specify a base for `parseInt` calls to avoid parsing bugs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686981e5a9a483239a618f70c69f3731